### PR TITLE
update makefiles to clean out build directories on build

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -14,7 +14,8 @@ help:
 # custom target for github pages
 github:
 	@make html
-	@cp -a _build/html/. ../docs
+	-rm -r ../docs
+	cp -a "$(BUILDDIR)/html/." ../docs
 	python trim.py ../docs/index.html
 
 .PHONY: help Makefile
@@ -23,4 +24,5 @@ github:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	python build_definitions.py
+	-rm -r "$(BUILDDIR)"
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/source/make.bat
+++ b/source/make.bat
@@ -32,9 +32,11 @@ if errorlevel 9009 (
 )
 
 python build_definitions.py
+rmdir /s /q %BUILDDIR%
 %SPHINXBUILD% -M %BUILDMODE% %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 
 if "%1" == "github" (
+    rmdir /s /q ..\docs
     robocopy %BUILDDIR%/html ../docs /E > nul
     echo.Generated files copied to ../docs
 	python trim.py ../docs/index.html


### PR DESCRIPTION
Todd was experiencing an issue where the built docs weren't reflecting changes in the source code and solved it by deleting the build directories and rebuilding.  This adds those steps to every build automatically. 