### PR TITLE
fix intersphinx url

### DIFF
--- a/source/intersphinx.rst
+++ b/source/intersphinx.rst
@@ -11,7 +11,7 @@ to recognize ``pv-terms`` as a linking target by adding an entry to the
 ::
 
     intersphinx_mapping = {
-        'pv-terms': ('https://duramat.github.io/pv-terms/pv-terms/', None),
+        'pv-terms': ('https://duramat.github.io/pv-terms/', None),
     }
 
 This lets you write references like this:


### PR DESCRIPTION
The intersphinx instructions have the wrong url, this just removes a duplicated portion. 